### PR TITLE
Fix bug in mark and unmark command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -51,6 +51,8 @@ public class Messages {
 
     public static final String MESSAGE_ALL_STUDENT_ATTENDANCE_UNMARKED = "All students marked as absent.";
     public static final String MESSAGE_ALL_STUDENT_ATTENDANCE_MARKED = "All students marked as present.";
+    public static final String MESSAGE_STUDENT_ALREADY_MARKED = "Student %1$s is already marked as present.";
+    public static final String MESSAGE_STUDENT_ALREADY_UNMARKED = "Student %1$s is already marked as absent.";
 
     //used by add
     public static final String MESSAGE_ADD_SUCCESS = "New student added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_STUDENT_ALREADY_MARKED;
 import static seedu.address.logic.Messages.MESSAGE_STUDENT_ATTENDANCE_MARKED;
 import static seedu.address.logic.Messages.MESSAGE_STUDENT_ID_NOT_FOUND;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
@@ -42,6 +43,9 @@ public class MarkCommand extends Command {
 
         try {
             Student studentToMark = model.getStudentById(studentId);
+            if (studentToMark.getIsPresentToday()) {
+                throw new CommandException(String.format(MESSAGE_STUDENT_ALREADY_MARKED, studentId));
+            }
             studentToMark.setPresent();
         } catch (NoSuchElementException e) {
             throw new CommandException(String.format(MESSAGE_STUDENT_ID_NOT_FOUND, studentId));

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_STUDENT_ALREADY_UNMARKED;
 import static seedu.address.logic.Messages.MESSAGE_STUDENT_ATTENDANCE_UNMARKED;
 import static seedu.address.logic.Messages.MESSAGE_STUDENT_ID_NOT_FOUND;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
@@ -42,6 +43,9 @@ public class UnmarkCommand extends Command {
 
         try {
             Student studentToMark = model.getStudentById(studentId);
+            if (!studentToMark.getIsPresentToday()) {
+                throw new CommandException(String.format(MESSAGE_STUDENT_ALREADY_UNMARKED, studentId));
+            }
             studentToMark.setAbsent();
         } catch (NoSuchElementException e) {
             throw new CommandException(String.format(MESSAGE_STUDENT_ID_NOT_FOUND, studentId));

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.student.Student;
 import seedu.address.model.student.StudentId;
 
 /**
@@ -44,7 +45,9 @@ public class UnmarkCommandTest {
 
     @Test
     public void execute_studentIdFound_success() {
-        final StudentId testId = model.getFilteredStudentList().get(0).getStudentId();
+        final Student testStudent = model.getFilteredStudentList().get(0);
+        final StudentId testId = testStudent.getStudentId();
+        testStudent.setPresent();
 
         String expectedMessage = String.format(MESSAGE_STUDENT_ATTENDANCE_UNMARKED, testId);
 


### PR DESCRIPTION
When attendance is already set as present, mark should return error message stating that student is already marked as present. Similar case with unmark command, it should return message that student is already marked as absent. Fixed bug.